### PR TITLE
Adding context to params to get LSP working with results

### DIFF
--- a/lua/preview-me/previewer.lua
+++ b/lua/preview-me/previewer.lua
@@ -12,6 +12,7 @@ config.init()
 function previewer.open_references()
 	-- Get the references and set them on the state
 	local params = vim.lsp.util.make_position_params()
+	params.context = { includeDeclaration = true }
 	local references, err = vim.lsp.buf_request_sync(0, "textDocument/references", params, 5000)
 	if err then
 		print(string.format("Got an error: %s", err))


### PR DESCRIPTION
Issue #3 

This change fixes the issue where results were not being returned in certain file and project types by adding in the `includeDeclaration` key and setting it to `true`.